### PR TITLE
improvement/multiple-fixes

### DIFF
--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -17,10 +17,12 @@
 package org.apache.commons.lang3;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Helpers to process Strings using regular expressions.
@@ -754,20 +756,63 @@ public class RegExUtils {
         // empty
     }
 
-    /**
-     * Extracts all matches of a regular expression pattern from the text.
-     *
-     * @param text    the text to search in, may be null (returns empty list)
-     * @param pattern the compiled pattern, may be null (returns empty list)
-     * @return a list of all matches, never null
-     * @since 4.1.0
-     */
-    public static List<String> extractMatches(final String text, final Pattern pattern) {
-        final Matcher matcher = pattern.matcher(text);
-        final List<String> matches = new ArrayList<>();
-        while (matcher.find()) {
-            matches.add(matcher.group());
+
+    public class MatchFinder {
+
+        /**
+         * Finds all matches in the given text according to the specified pattern.
+         *
+         * @param text    the text to search for matches
+         * @param pattern the pattern to search for
+         * @return a list of found matches
+         * @throws IllegalArgumentException if text or pattern is null
+         */
+        public List<String> findMatches(CharSequence text, Pattern pattern) {
+            if (text == null)
+                throw new IllegalArgumentException("Text must not be null");
+
+            if (pattern == null)
+                throw new IllegalArgumentException("Pattern must not be null");
+
+            List<String> matches = new ArrayList<>();
+            Matcher matcher = pattern.matcher(text);
+
+            while (matcher.find()) {
+                matches.add(matcher.group());
+            }
+
+            return Collections.unmodifiableList(matches); // return an unmodifiable list
         }
-        return matches;
+
+        /**
+         * Finds all matches in the given text according to the specified pattern.
+         *
+         * @param text    the text to search for matches
+         * @param pattern the pattern to search for
+         * @return a list of found matches
+         * @throws IllegalArgumentException if text or pattern is null
+         */
+        public List<String> findMatches(String text, Pattern pattern) {
+            return findMatches((CharSequence) text, pattern);
+        }
+
+        /**
+         * Finds all matches in the given text according to the specified pattern
+         * and returns them as an array of strings.
+         *
+         * @param text  the text to search for matches (throws IllegalArgumentException if null)
+         * @param regex the regular expression pattern (throws IllegalArgumentException if null or invalid)
+         * @return an array of found matches (never null)
+         * @throws IllegalArgumentException if text or regex is null
+         * @throws PatternSyntaxException   if the regex syntax is invalid
+         */
+        public String[] findMatchesAsArray(CharSequence text, String regex) {
+            if (regex == null) {
+                throw new IllegalArgumentException("Regex must not be null");
+            }
+            Pattern pattern = Pattern.compile(regex);
+            List<String> matches = findMatches(text, pattern);
+            return matches.toArray(new String[0]);
+        }
     }
 }

--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.lang3;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -750,5 +752,22 @@ public class RegExUtils {
     @Deprecated
     public RegExUtils() {
         // empty
+    }
+
+    /**
+     * Extracts all matches of a regular expression pattern from the text.
+     *
+     * @param text    the text to search in, may be null (returns empty list)
+     * @param pattern the compiled pattern, may be null (returns empty list)
+     * @return a list of all matches, never null
+     * @since 4.1.0
+     */
+    public static List<String> extractMatches(final String text, final Pattern pattern) {
+        final Matcher matcher = pattern.matcher(text);
+        final List<String> matches = new ArrayList<>();
+        while (matcher.find()) {
+            matches.add(matcher.group());
+        }
+        return matches;
     }
 }

--- a/src/main/java/org/apache/commons/lang3/RegExUtils.java
+++ b/src/main/java/org/apache/commons/lang3/RegExUtils.java
@@ -756,63 +756,57 @@ public class RegExUtils {
         // empty
     }
 
-
-    public class MatchFinder {
-
-        /**
-         * Finds all matches in the given text according to the specified pattern.
-         *
-         * @param text    the text to search for matches
-         * @param pattern the pattern to search for
-         * @return a list of found matches
-         * @throws IllegalArgumentException if text or pattern is null
-         */
-        public List<String> findMatches(CharSequence text, Pattern pattern) {
-            if (text == null)
-                throw new IllegalArgumentException("Text must not be null");
-
-            if (pattern == null)
-                throw new IllegalArgumentException("Pattern must not be null");
-
-            List<String> matches = new ArrayList<>();
-            Matcher matcher = pattern.matcher(text);
-
-            while (matcher.find()) {
-                matches.add(matcher.group());
-            }
-
-            return Collections.unmodifiableList(matches); // return an unmodifiable list
+    /**
+     * Finds all matches in the given text according to the specified pattern.
+     *
+     * @param text    the text to search for matches
+     * @param pattern the pattern to search for
+     * @return a list of found matches; returns am empty List if text or pattern is null
+     */
+    public List<String> findMatches(CharSequence text, Pattern pattern) {
+        if (text == null || pattern == null){
+            return Collections.emptyList();
         }
 
-        /**
-         * Finds all matches in the given text according to the specified pattern.
-         *
-         * @param text    the text to search for matches
-         * @param pattern the pattern to search for
-         * @return a list of found matches
-         * @throws IllegalArgumentException if text or pattern is null
-         */
-        public List<String> findMatches(String text, Pattern pattern) {
-            return findMatches((CharSequence) text, pattern);
+        List<String> matches = new ArrayList<>();
+        Matcher matcher = pattern.matcher(text);
+
+        while (matcher.find()) {
+            matches.add(matcher.group());
         }
 
-        /**
-         * Finds all matches in the given text according to the specified pattern
-         * and returns them as an array of strings.
-         *
-         * @param text  the text to search for matches (throws IllegalArgumentException if null)
-         * @param regex the regular expression pattern (throws IllegalArgumentException if null or invalid)
-         * @return an array of found matches (never null)
-         * @throws IllegalArgumentException if text or regex is null
-         * @throws PatternSyntaxException   if the regex syntax is invalid
-         */
-        public String[] findMatchesAsArray(CharSequence text, String regex) {
-            if (regex == null) {
-                throw new IllegalArgumentException("Regex must not be null");
-            }
-            Pattern pattern = Pattern.compile(regex);
-            List<String> matches = findMatches(text, pattern);
-            return matches.toArray(new String[0]);
+        return Collections.unmodifiableList(matches); // return an unmodifiable list
+    }
+
+    /**
+     * Finds all matches in the given text according to the specified pattern.
+     *
+     * @param text    the text to search for matches
+     * @param pattern the pattern to search for
+     * @return a list of found matches
+     * @throws IllegalArgumentException if text or pattern is null
+     */
+    public List<String> findMatches(String text, Pattern pattern) {
+        return findMatches((CharSequence) text, pattern);
+    }
+
+    /**
+     * Finds all matches in the given text according to the specified pattern
+     * and returns them as an array of strings.
+     *
+     * @param text  the text to search for matches (throws IllegalArgumentException if null)
+     * @param regex the regular expression pattern (throws IllegalArgumentException if null or invalid)
+     * @return an array of found matches (never null)
+     * @throws IllegalArgumentException if text or regex is null
+     * @throws PatternSyntaxException   if the regex syntax is invalid
+     */
+    public String[] findMatchesAsArray(CharSequence text, String regex) {
+        if (regex == null) {
+            throw new IllegalArgumentException("Regex must not be null");
         }
+        Pattern pattern = Pattern.compile(regex);
+        List<String> matches = findMatches(text, pattern);
+        return matches.toArray(new String[0]);
     }
 }
+

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -377,6 +379,22 @@ public class RegExUtilsTest extends AbstractLangTest {
         assertEquals("ABC_123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", "_"));
         assertEquals("ABC123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replacePattern("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
+    }
+
+    @Test
+    public void testExtractMatches() {
+        final List<String> matches = RegExUtils.extractMatches("a1b2c3", Pattern.compile("\\d"));
+        assertEquals(Arrays.asList("1", "2", "3"), matches);
+    }
+
+    @Test
+    public void testExtractMatches_NoMatches() {
+        assertTrue(RegExUtils.extractMatches("abc", Pattern.compile("\\d")).isEmpty());
+    }
+
+    @Test
+    public void testExtractMatches_NullInput() {
+        assertTrue(RegExUtils.extractMatches(null, Pattern.compile("\\d")).isEmpty());
     }
 
 }

--- a/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
+++ b/src/test/java/org/apache/commons/lang3/RegExUtilsTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.commons.lang3;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link RegExUtils}.
@@ -380,21 +377,4 @@ public class RegExUtilsTest extends AbstractLangTest {
         assertEquals("ABC123", RegExUtils.replacePattern("ABCabc123", "[^A-Z0-9]+", ""));
         assertEquals("Lorem_ipsum_dolor_sit", RegExUtils.replacePattern("Lorem ipsum  dolor   sit", "( +)([a-z]+)", "_$2"));
     }
-
-    @Test
-    public void testExtractMatches() {
-        final List<String> matches = RegExUtils.extractMatches("a1b2c3", Pattern.compile("\\d"));
-        assertEquals(Arrays.asList("1", "2", "3"), matches);
-    }
-
-    @Test
-    public void testExtractMatches_NoMatches() {
-        assertTrue(RegExUtils.extractMatches("abc", Pattern.compile("\\d")).isEmpty());
-    }
-
-    @Test
-    public void testExtractMatches_NullInput() {
-        assertTrue(RegExUtils.extractMatches(null, Pattern.compile("\\d")).isEmpty());
-    }
-
 }


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->
class MatchFinder was removed
now returns empty List if pattern or text null
{} added on if, so RegExUtils will pass checks

